### PR TITLE
Update firmware.md

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -2749,7 +2749,7 @@ The parameter for millis is an unsigned long, errors may be generated if a progr
 
 ### micros()
 
-Returns the number of microseconds since the device began running the current program. This number will overflow (go back to zero), after approximately 59.65 seconds.
+Returns the number of microseconds since the device began running the current program. This number will overflow (go back to zero), after exactly 59,652,323 microseconds (0 .. 59,652,322). Note: This number is different for the Photon.
 
 `unsigned long time = micros();`
 


### PR DESCRIPTION
More accurately describe the way the micros() function currently behaves. There is a pull request pending in firmware to fix this, but this is the way it currently behaves.